### PR TITLE
Fix missing quality options in web UI 480p and 360p

### DIFF
--- a/app.py
+++ b/app.py
@@ -333,6 +333,8 @@ def handle_start_download(data):
     quality_map = {
         "best_mp4": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
         "720p_mp4": "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best",
+        "480p_mp4": "bestvideo[height<=480][ext=mp4]+bestaudio[ext=m4a]/best[height<=480][ext=mp4]/best",
+        "360p_mp4": "bestvideo[height<=360][ext=mp4]+bestaudio[ext=m4a]/best[height<=360][ext=mp4]/best",
         "mp3": "bestaudio/best"
     }
     

--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@
                             <option value="best_mp4">Best Video (MP4)</option>
                             <option value="720p_mp4">720p Video (MP4)</option>
                             <option value="480p_mp4">480p Video (MP4)</option>
+                            <option value="360p_mp4">360p Video (MP4)</option>
                             <option value="mp3">Audio Only (MP3)</option>
                         </select>
                     </div>


### PR DESCRIPTION
The web UI offered 480p and 360p download options, but the backend was not configured to handle them. This caused an error when a user selected either of these options.

This commit adds the necessary mappings for '480p_mp4' and '360p_mp4' to the `quality_map` dictionary in `app.py`. It also adds the missing '360p_mp4' option to the dropdown in `index.html`.